### PR TITLE
Handle CBR/CBZ files case-insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Turn a folder of `.cbr` comic book archives into a single, neatly-tiled poster o
 
 ##  Features & Workflow
 
-- Scans a folder for `.cbr` files (supports `.cbz` mislabeled as `.cbr`)
+- Scans a folder for `.cbr` and `.cbz` files (case-insensitive)
 - Extracts the **first image** (usually the cover) from each archive
 - Resizes all covers to a uniform height (default: 600px)
 - Tiles them into a single poster, auto-adjusting columns and rows

--- a/poster.py
+++ b/poster.py
@@ -36,12 +36,16 @@ def _save_image(raw: bytes, member: str, out: Path):
 
 
 def extract_covers(src: Path, out: Path, unrar: str) -> list[Path]:
-    """Grab first JPG/PNG/WebP from each .cbr (or mis-labelled .cbz)."""
+    """Grab first JPG/PNG/WebP from each .cbr/.cbz archive."""
     rarfile.UNRAR_TOOL = unrar
     out.mkdir(exist_ok=True)
     got: list[Path] = []
 
-    for arc in sorted(src.glob("*.cbr")):
+    archives = sorted(
+        p for p in src.iterdir() if p.suffix.lower() in {".cbr", ".cbz"}
+    )
+
+    for arc in archives:
         stem = arc.stem
         handled = False
 
@@ -63,7 +67,7 @@ def extract_covers(src: Path, out: Path, unrar: str) -> list[Path]:
         except rarfile.Error:
             pass
 
-        # fallback: ZIP ( mis-labelled CBZ CBR )
+        # fallback: ZIP (.cbz or mis-labelled .cbr)
         if not handled:
             try:
                 with zipfile.ZipFile(arc) as zf:


### PR DESCRIPTION
## Summary
- support `.cbr` and `.cbz` archives without regard to case
- document the broader archive support in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689516be4e40832eb52916c192a0fad3